### PR TITLE
add aliases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/target
+.idea

--- a/Adventskalender.iml
+++ b/Adventskalender.iml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module version="4">
+  <component name="FacetManager">
+    <facet type="minecraft" name="Minecraft">
+      <configuration>
+        <autoDetectTypes>
+          <platformType>SPIGOT</platformType>
+        </autoDetectTypes>
+        <projectReimportVersion>1</projectReimportVersion>
+      </configuration>
+    </facet>
+  </component>
+</module>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>Adventskalender</groupId>
 	<artifactId>Adventskalender</artifactId>
-	<version>2.0</version>
+	<version>2.1</version>
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -12,6 +12,12 @@
 
 	<build>
 		<sourceDirectory>src</sourceDirectory>
+		<resources>
+			<resource>
+				<directory>resources</directory>
+				<filtering>true</filtering>
+			</resource>
+		</resources>
 		<plugins>
 			<plugin>
 				<artifactId>maven-compiler-plugin</artifactId>
@@ -58,7 +64,7 @@
 		<dependency>
 			<groupId>org.spigotmc</groupId>
 			<artifactId>spigot-api</artifactId>
-			<version>1.19.2-R0.1-SNAPSHOT</version>
+			<version>1.20.2-R0.1-SNAPSHOT</version>
 			<scope>provided</scope>
 		</dependency>
 		<!--This adds bstats to the build -->

--- a/resources/plugin.yml
+++ b/resources/plugin.yml
@@ -20,6 +20,7 @@ permissions:
 commands:
     adventskalender:
         description: "Zeigt den Adventskalender an"
+        aliases: [adventcalendar , adc]
         permission: adventskalender.command
         permission-message: "Du hast nicht die Berechtigung den Adventskalender aufzurufen"
     

--- a/resources/plugin.yml
+++ b/resources/plugin.yml
@@ -1,10 +1,10 @@
 name: Adventskalender
-version: 2.0
+version: 2.1
 description: A german culture christmas calendar
 author: Scientarus
 website: https://www.spigotmc.org/resources/adventskalender.97821
 
-api-version: 1.19
+api-version: '1.20'
 load: POSTWORLD
 main: de.scientarus.adventskalender.main.Main
 


### PR DESCRIPTION
Just a small change: Add aliases for the `adventskalender` command. Many of the players on my server speak only English and I can't ask them to write a german word 😄 

I couldn't try the change on my server because I'm not able to generate the **jar** file with IntelliJ IDEA. Could you please tell me the correct command to build it? usually, I have the `resources` folder inside `/scr/main/` like [here](https://github.com/MajdT51/DiamondGuarantee). 

Update: I was able to test the aliases on my local server. I had to add the path of resources in the pom.xml to be able to generate the jar correctly